### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Yurikleb DRV2605 Library
-version=1.0.
+version=1.0.0
 author=Yurikleb
 maintainer=Yurikleb <yurikleb@gmail.com>
 sentence=Arduino library for TI DRV2667 Hapic Piezo Driver


### PR DESCRIPTION
The previous version value caused the Arduino IDE to display warnings:
```
Invalid version found: 1.0.
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format